### PR TITLE
Add live scoring web UI with TBA-powered district points

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ POSTGRES_PASSWORD=fantasyfirst
 # SLACK_CLIENT_ID=your-client-id
 # SLACK_CLIENT_SECRET=your-client-secret
 # SLACK_STATE_SECRET=some-random-secret
+
+# Public URL for live scoring links (include protocol, no trailing slash)
+# Leave blank to disable scoring links in Slack messages (local dev mode)
+# PUBLIC_URL=https://your-bot-host.example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+# ── Web frontend builder ───────────────────────────────────────────────────────
+FROM node:20-alpine AS web-builder
+WORKDIR /app/web
+
+COPY web/package*.json ./
+RUN npm ci
+
+COPY web/ ./
+RUN npm run build
+
+# ── Server builder ─────────────────────────────────────────────────────────────
 FROM node:20-alpine AS builder
 WORKDIR /app
 
@@ -9,9 +20,9 @@ RUN npx prisma generate
 
 COPY tsconfig.json ./
 COPY src ./src/
-RUN npm run build
+RUN npx tsc
 
-# ── Production image ──────────────────────────────────────────────────────────
+# ── Production image ───────────────────────────────────────────────────────────
 FROM node:20-alpine
 WORKDIR /app
 
@@ -22,6 +33,7 @@ RUN npm ci --omit=dev
 RUN npx prisma generate
 
 COPY --from=builder /app/dist ./dist/
+COPY --from=web-builder /app/web/dist ./web/dist/
 
 EXPOSE 3000
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^5.10.0",
-        "@slack/bolt": "^3.21.3"
+        "@slack/bolt": "^3.21.3",
+        "express": "^4.22.2"
       },
       "devDependencies": {
+        "@types/express": "^4.17.25",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.5",
         "jest": "^29.7.0",
@@ -76,31 +78,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
-    },
-    "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
@@ -520,31 +497,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
@@ -1556,29 +1508,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1933,6 +1862,21 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -2386,12 +2330,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/dedent": {
@@ -2906,6 +2858,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/express/node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -2959,6 +2926,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -3422,29 +3404,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4027,31 +3986,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
@@ -4761,12 +4695,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -5069,9 +4997,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -5863,10 +5791,19 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A Slack bot for Fantasy First draft games",
   "main": "dist/app.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run build:web",
+    "build:web": "cd web && npm ci && npm run build",
     "start": "node dist/app.js",
     "dev": "ts-node src/app.ts",
     "db:generate": "prisma generate",
@@ -17,9 +18,11 @@
   },
   "dependencies": {
     "@prisma/client": "^5.10.0",
-    "@slack/bolt": "^3.21.3"
+    "@slack/bolt": "^3.21.3",
+    "express": "^4.22.2"
   },
   "devDependencies": {
+    "@types/express": "^4.17.25",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.5",
     "jest": "^29.7.0",

--- a/prisma/migrations/20250521000000_add_event_code/migration.sql
+++ b/prisma/migrations/20250521000000_add_event_code/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "games" ADD COLUMN "event_code" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Game {
   turnCount            Int      @default(0) @map("turn_count")
   lastMessagesTsArray  Json     @default("[]") @map("last_messages_ts_array")
   targetPlayersPerGame Int      @default(0) @map("target_players_per_game")
+  eventCode            String?  @map("event_code")
   createdAt            DateTime @default(now()) @map("created_at")
   updatedAt            DateTime @updatedAt @map("updated_at")
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
-import { App, LogLevel } from '@slack/bolt';
+import { App, ExpressReceiver, LogLevel } from '@slack/bolt';
+import express from 'express';
 import { registerAppHomeHandler } from './slack/handlers/appHome';
 import { registerCreateEventHandlers } from './slack/handlers/createEvent';
 import { registerJoinLeaveHandlers } from './slack/handlers/joinLeave';
@@ -8,18 +9,26 @@ import { registerAdminHandler } from './slack/handlers/admin';
 import { initializeState } from './state';
 import { loadAllGames, prisma } from './utils/persistence';
 import { PORT } from './constants';
+import { createWebRouter } from './web/router';
 
 const isSingleWorkspace = Boolean(process.env.SLACK_BOT_TOKEN);
+const signingSecret = process.env.SLACK_SIGNING_SECRET!;
+
+const receiver = new ExpressReceiver({ signingSecret });
+
+// Mount custom routes before Slack handlers
+receiver.app.use(express.json());
+receiver.app.use(createWebRouter());
 
 const app = new App(
   isSingleWorkspace
     ? {
         token: process.env.SLACK_BOT_TOKEN,
-        signingSecret: process.env.SLACK_SIGNING_SECRET!,
+        receiver,
         logLevel: LogLevel.INFO,
       }
     : {
-        signingSecret: process.env.SLACK_SIGNING_SECRET!,
+        receiver,
         clientId: process.env.SLACK_CLIENT_ID!,
         clientSecret: process.env.SLACK_CLIENT_SECRET!,
         stateSecret: process.env.SLACK_STATE_SECRET!,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const ADMIN_USER_ID = process.env.ADMIN_USER_ID ?? '';
 export const PORT = parseInt(process.env.PORT ?? '3000', 10);
+export const PUBLIC_URL = process.env.PUBLIC_URL ?? '';
 
 export const CREATE_EVENT_CALLBACK_ID = 'createEventButton';
 export const PICK_TEAM_CALLBACK_ID = 'team_pick_number';

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import type { KnownBlock } from '@slack/bolt';
 import { GameData, Player, Team } from '../types';
-import { ACTION_JOIN_GAME, ACTION_LEAVE_GAME, ACTION_PICK_TEAM_BUTTON, ACTION_START_GAME } from '../constants';
+import { ACTION_JOIN_GAME, ACTION_LEAVE_GAME, ACTION_PICK_TEAM_BUTTON, ACTION_START_GAME, PUBLIC_URL } from '../constants';
 
 export class Game {
   private readonly data: GameData;
@@ -17,6 +17,7 @@ export class Game {
     gameOwnerSlackId: string;
     gameName: string;
     targetPlayersPerGame?: number;
+    eventCode?: string;
   }): Game {
     const availableTeams = [...params.teams].sort(
       (a, b) => parseInt(a.number) - parseInt(b.number),
@@ -33,6 +34,7 @@ export class Game {
       turnCount: 0,
       lastMessagesTsArray: [],
       targetPlayersPerGame: params.targetPlayersPerGame ?? 0,
+      eventCode: params.eventCode,
     });
   }
 
@@ -55,11 +57,18 @@ export class Game {
   get availableTeams(): Team[] { return this.data.availableTeams; }
   get lastMessagesTsArray(): string[] { return this.data.lastMessagesTsArray; }
   get targetPlayersPerGame(): number { return this.data.targetPlayersPerGame; }
+  get eventCode(): string | undefined { return this.data.eventCode; }
 
   set gameName(name: string) { this.data.gameName = name; }
   set allianceSize(size: number) { this.data.allianceSize = size; }
   set targetPlayersPerGame(n: number) { this.data.targetPlayersPerGame = n; }
   set lastMessagesTsArray(ts: string[]) { this.data.lastMessagesTsArray = ts; }
+  set eventCode(code: string | undefined) { this.data.eventCode = code; }
+
+  getScoringUrl(publicUrl: string): string | null {
+    if (!publicUrl) return null;
+    return `${publicUrl}/game/${this.data.uuid}`;
+  }
 
   addPlayer(player: Player): void {
     this.data.players.push(player);
@@ -229,6 +238,10 @@ export class Game {
         type: 'context',
         elements: [{ type: 'mrkdwn', text: `This game will be split into drafts with a target of *${teamsPerDraft}* players per draft` }],
       },
+      ...(this.getScoringUrl(PUBLIC_URL) ? [{
+        type: 'context' as const,
+        elements: [{ type: 'mrkdwn' as const, text: `📊 <${this.getScoringUrl(PUBLIC_URL)}|Live Scoring>` }],
+      }] : []),
     ] as KnownBlock[];
   }
 
@@ -246,6 +259,10 @@ export class Game {
       return [[
         { type: 'section', text: { type: 'mrkdwn', text: `The *${this.data.gameName}* draft is over!` } },
         { type: 'section', fields },
+        ...(this.getScoringUrl(PUBLIC_URL) ? [{
+          type: 'context' as const,
+          elements: [{ type: 'mrkdwn' as const, text: `📊 <${this.getScoringUrl(PUBLIC_URL)}|Live Scoring>` }],
+        }] : []),
       ] as KnownBlock[]];
     }
 
@@ -264,6 +281,10 @@ export class Game {
       },
       { type: 'section', text: { type: 'mrkdwn', text: 'You can still join the draft!' } },
       this.getJoiningButtonsBlock(),
+      ...(this.getScoringUrl(PUBLIC_URL) ? [{
+        type: 'context' as const,
+        elements: [{ type: 'mrkdwn' as const, text: `📊 <${this.getScoringUrl(PUBLIC_URL)}|Live Scoring>` }],
+      }] : []),
     ] as KnownBlock[]];
   }
 

--- a/src/scoring/districtPoints.ts
+++ b/src/scoring/districtPoints.ts
@@ -1,0 +1,311 @@
+import { erfinv } from './erfinv';
+import { TbaAlliance, TbaAward, TbaMatchSimple, TbaRankingsResponse, TbaTeamSimple } from './tbaTypes';
+
+export interface DistrictPoints {
+  teamNumber: string;
+  qualPoints: number;
+  alliancePoints: number;
+  elimsPoints: number;
+  awardPoints: number;
+  total: number;
+}
+
+// --- Internal parsed types (mirrors the Python dataclasses) ---
+
+interface AllianceInfo {
+  allianceNumber: number;
+  teams: string[];      // team numbers, captain first
+  wins: number;
+  placement: number;    // 1=winner, 2=runner-up, 3, 4, 6, 8, -1=unknown
+}
+
+type MatchWinner = 'red' | 'blue' | 'tie';
+
+interface MatchInfo {
+  redAlliance: string[];
+  blueAlliance: string[];
+  winner: MatchWinner;
+  isQuals: boolean;
+  isFinals: boolean;
+}
+
+type AwardType = 'impact' | 'engineering_inspiration' | 'rookie_all_star' | 'other';
+
+interface AwardInfo {
+  teamNumber: string;
+  awardType: AwardType;
+}
+
+// --- TBA parsing helpers ---
+
+function teamKey(key: string): string {
+  return key.replace('frc', '').trim();
+}
+
+function allianceKeyToNumber(key: string | number | undefined, index: number): number {
+  if (typeof key === 'number') return key + 1;
+  if (!key) return index + 1;
+  const s = String(key).toLowerCase().replace(/\s/g, '').replace('alliance', '');
+  const n = parseFloat(s);
+  return isNaN(n) ? index + 1 : n;
+}
+
+export function parseRankings(raw: TbaRankingsResponse | null): string[] {
+  if (!raw || !raw.rankings) return [];
+  const sorted = [...raw.rankings].sort((a, b) => a.rank - b.rank);
+  return sorted.map(r => teamKey(r.team_key));
+}
+
+export function parseAlliances(raw: TbaAlliance[]): AllianceInfo[] {
+  return raw.map((a, i) => {
+    const allianceNumber = allianceKeyToNumber(a.name, i);
+    const teams = a.picks.map(teamKey);
+    const wins = a.status?.record?.wins ?? 0;
+
+    let placement = -1;
+    switch (a.status?.double_elim_round) {
+      case 'Finals':   placement = 1; break;
+      case 'Round 5':  placement = 3; break;
+      case 'Round 4':  placement = 4; break;
+      case 'Round 3':  placement = 6; break;
+      case 'Round 2':  placement = 8; break;
+    }
+    if (placement === 1 && a.status?.status === 'eliminated') placement = 2;
+
+    return { allianceNumber, teams, wins, placement };
+  }).sort((a, b) => a.allianceNumber - b.allianceNumber);
+}
+
+export function parseMatches(raw: TbaMatchSimple[]): MatchInfo[] {
+  return raw.map(m => {
+    let winner: MatchWinner = 'tie';
+    if (m.winning_alliance === 'red') winner = 'red';
+    else if (m.winning_alliance === 'blue') winner = 'blue';
+    return {
+      redAlliance: m.alliances.red.team_keys.map(teamKey),
+      blueAlliance: m.alliances.blue.team_keys.map(teamKey),
+      winner,
+      isQuals: m.comp_level === 'qm',
+      isFinals: m.comp_level === 'f',
+    };
+  });
+}
+
+export function parseAwards(raw: TbaAward[]): AwardInfo[] {
+  const out: AwardInfo[] = [];
+  for (const award of raw) {
+    // Skip: Impact Award (1), EI trophy (2), Rookie All-Star (68)
+    if ([1, 2, 68].includes(award.award_type)) continue;
+
+    let awardType: AwardType;
+    switch (award.award_type) {
+      case 0:  awardType = 'impact'; break;
+      case 9:  awardType = 'engineering_inspiration'; break;
+      case 10: awardType = 'rookie_all_star'; break;
+      default: awardType = 'other';
+    }
+
+    for (const recipient of award.recipient_list) {
+      if (!recipient.team_key) continue;
+      if (recipient.awardee) continue;  // individual award, not team
+      out.push({ teamNumber: teamKey(recipient.team_key), awardType });
+    }
+  }
+  return out;
+}
+
+export function parseTeamNames(raw: TbaTeamSimple[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const t of raw) {
+    map.set(String(t.team_number), t.nickname || String(t.team_number));
+  }
+  return map;
+}
+
+// --- Scoring functions (ported 1:1 from Python) ---
+
+const A = 1.07;
+
+function calculateQualPoints(rankings: string[]): Record<string, number> {
+  const n = rankings.length;
+  if (n === 0) return {};
+  const normalizer = erfinv(1 / A);
+
+  const out: Record<string, number> = {};
+  for (let i = 0; i < rankings.length; i++) {
+    const r = i + 1;
+    const x = (n - 2 * r + 2) / (A * n);
+    const raw = erfinv(x);
+    const pts = 12 + (10 / normalizer) * raw;
+    out[rankings[i]] = Math.ceil(pts);
+  }
+  return out;
+}
+
+function allianceSize(alliances: AllianceInfo[]): number {
+  let min = Number.MAX_SAFE_INTEGER;
+  for (const a of alliances) min = Math.min(min, a.teams.length);
+  return min === Number.MAX_SAFE_INTEGER ? 0 : min;
+}
+
+function calculateAllianceCaptainPoints(alliances: AllianceInfo[]): Record<string, number> {
+  const size = allianceSize(alliances);
+  const maxPoints = (size - 1) * alliances.length + 1;
+  const out: Record<string, number> = {};
+  for (const a of alliances) {
+    const captain = a.teams[0];
+    out[captain] = maxPoints - a.allianceNumber;
+  }
+  return out;
+}
+
+// _is_serpentine: IRI events are not serpentine, but function is otherwise unused.
+// Ported for parity.
+export function isSerpentine(eventCode: string): boolean {
+  return !eventCode.includes('iri');
+}
+
+function teamsAcceptedByOrder(alliances: AllianceInfo[]): string[] {
+  const size = allianceSize(alliances);
+  if (size <= 1) return [];
+
+  // Flatten picks (excluding captains at index 0), column by column
+  const flatPicks: string[] = [];
+  for (let pickCol = 1; pickCol < size; pickCol++) {
+    for (const a of alliances) {
+      if (a.teams.length > pickCol) flatPicks.push(a.teams[pickCol]);
+    }
+  }
+
+  const pickCount = size - 1;
+  const allianceCount = alliances.length;
+  let reverseSection = false;
+  const out: string[] = [];
+
+  for (let i = 0; i < pickCount; i++) {
+    const start = i * allianceCount;
+    const end = (i + 1) * allianceCount;
+    let section = flatPicks.slice(start, end);
+    if (reverseSection) section = [...section].reverse();
+    out.push(...section);
+    reverseSection = !reverseSection;
+  }
+  return out;
+}
+
+function calculateDraftAcceptancePoints(alliances: AllianceInfo[]): Record<string, number> {
+  const size = allianceSize(alliances);
+  const maxPoints = (size - 1) * alliances.length + 1;
+  const out: Record<string, number> = {};
+  const ordered = teamsAcceptedByOrder(alliances);
+  for (let i = 0; i < ordered.length; i++) {
+    out[ordered[i]] = maxPoints - (i + 1);
+  }
+  return out;
+}
+
+function calculateElimsPoints(alliances: AllianceInfo[], matches: MatchInfo[]): Record<string, number> {
+  const allianceLookup = new Map<string, AllianceInfo>();
+  const elimsWon = new Map<string, number>();
+  const finalsWon = new Map<string, number>();
+  const out: Record<string, number> = {};
+
+  for (const a of alliances) {
+    for (const team of a.teams) {
+      allianceLookup.set(team, a);
+      elimsWon.set(team, 0);
+      finalsWon.set(team, 0);
+      out[team] = 0;
+    }
+  }
+
+  for (const match of matches) {
+    if (match.isQuals || match.winner === 'tie') continue;
+    const winners = match.winner === 'red' ? match.redAlliance : match.blueAlliance;
+    for (const team of winners) {
+      elimsWon.set(team, (elimsWon.get(team) ?? 0) + 1);
+      if (match.isFinals) finalsWon.set(team, (finalsWon.get(team) ?? 0) + 1);
+    }
+  }
+
+  for (const [team, wins] of elimsWon) {
+    const alliance = allianceLookup.get(team);
+    if (!alliance || !alliance.wins) continue;
+
+    let alliancePoints = 0;
+    switch (alliance.placement) {
+      case 1: case 2: alliancePoints = 20; break;
+      case 3: alliancePoints = 13; break;
+      case 4: alliancePoints = 7; break;
+      default: alliancePoints = 0;
+    }
+    out[team] = (wins / alliance.wins) * alliancePoints;
+  }
+
+  // Finals bonus for the winning alliance only
+  for (const [team, fwins] of finalsWon) {
+    const alliance = allianceLookup.get(team);
+    if (!alliance || alliance.placement !== 1) continue;
+    out[team] += Math.min(10, fwins * 5);
+  }
+
+  return out;
+}
+
+function calculateAwardPoints(awards: AwardInfo[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const award of awards) {
+    let pts: number;
+    switch (award.awardType) {
+      case 'impact': pts = 10; break;
+      case 'engineering_inspiration': pts = 8; break;
+      case 'rookie_all_star': pts = 8; break;
+      default: pts = 5;
+    }
+    out[award.teamNumber] = (out[award.teamNumber] ?? 0) + pts;
+  }
+  return out;
+}
+
+// --- Public entry point ---
+
+export function calculateDistrictPoints(input: {
+  rankings: string[];
+  alliances: TbaAlliance[];
+  matches: TbaMatchSimple[];
+  awards: TbaAward[];
+  teams: TbaTeamSimple[];
+}): Record<string, DistrictPoints> {
+  const parsedAlliances = parseAlliances(input.alliances);
+  const parsedMatches = parseMatches(input.matches);
+  const parsedAwards = parseAwards(input.awards);
+
+  // Merge team list and rankings so teams not in rankings still appear
+  const allTeamNumbers = new Set<string>();
+  for (const t of input.teams) allTeamNumbers.add(String(t.team_number));
+  for (const r of input.rankings) allTeamNumbers.add(r);
+
+  const qualPts = calculateQualPoints(input.rankings);
+  const captainPts = calculateAllianceCaptainPoints(parsedAlliances);
+  const acceptancePts = calculateDraftAcceptancePoints(parsedAlliances);
+  const elimsPts = calculateElimsPoints(parsedAlliances, parsedMatches);
+  const awardPts = calculateAwardPoints(parsedAwards);
+
+  const out: Record<string, DistrictPoints> = {};
+  for (const teamNumber of allTeamNumbers) {
+    const alliancePoints = (captainPts[teamNumber] ?? 0) + (acceptancePts[teamNumber] ?? 0);
+    const elimsPoints = elimsPts[teamNumber] ?? 0;
+    const awardPoints = awardPts[teamNumber] ?? 0;
+    const qualPoints = qualPts[teamNumber] ?? 0;
+    out[teamNumber] = {
+      teamNumber,
+      qualPoints,
+      alliancePoints,
+      elimsPoints,
+      awardPoints,
+      total: qualPoints + alliancePoints + elimsPoints + awardPoints,
+      // team_age_points intentionally excluded from total, per Python source
+    };
+  }
+  return out;
+}

--- a/src/scoring/draftHistory.ts
+++ b/src/scoring/draftHistory.ts
@@ -1,0 +1,49 @@
+import { Game } from '../game/Game';
+
+export interface PickRecord {
+  playerSlackId: string;
+  playerName: string;
+  round: number;         // 1-indexed
+  pickIndex: number;     // 0-indexed within the player's selectedTeams
+  teamNumber: string;
+  poolBefore: string[];  // team numbers available immediately before this pick
+}
+
+export function reconstructPicks(game: Game): PickRecord[] {
+  const players = game.players;
+  const allianceSize = game.allianceSize;
+  if (!game.hasStarted || players.length === 0) return [];
+
+  // Rebuild the full team pool at draft start = available now + all selected
+  const pool = new Set<string>();
+  for (const t of game.availableTeams) pool.add(t.number);
+  for (const p of players) {
+    for (const t of p.selectedTeams) pool.add(t.number);
+  }
+
+  const picks: PickRecord[] = [];
+
+  for (let round = 1; round <= allianceSize; round++) {
+    const playerOrder = round % 2 === 0
+      ? [...players].reverse()
+      : [...players];
+
+    for (const player of playerOrder) {
+      const pickIndex = round - 1;
+      if (player.selectedTeams.length <= pickIndex) continue; // player didn't pick this round
+
+      const team = player.selectedTeams[pickIndex];
+      picks.push({
+        playerSlackId: player.slackId,
+        playerName: player.name,
+        round,
+        pickIndex,
+        teamNumber: team.number,
+        poolBefore: [...pool],
+      });
+      pool.delete(team.number);
+    }
+  }
+
+  return picks;
+}

--- a/src/scoring/erfinv.ts
+++ b/src/scoring/erfinv.ts
@@ -1,0 +1,75 @@
+// Inverse error function — matches scipy.special.erfinv to within ~1e-12.
+// Uses Acklam's rational approximation for the probit function (converted via
+// erfinv(x) = probit((x+1)/2) / sqrt(2)) followed by Newton-Raphson refinement
+// using a high-accuracy Taylor-series erf.
+
+const SQRT2 = Math.SQRT2;
+const TWO_OVER_SQRTPI = 2 / Math.sqrt(Math.PI);
+const SQRT_TWO_PI = Math.sqrt(2 * Math.PI);
+
+function erfTaylor(x: number): number {
+  if (Math.abs(x) >= 5) return x > 0 ? 1 : -1;
+  const x2 = x * x;
+  let term = x;
+  let sum = x;
+  for (let n = 1; n <= 120; n++) {
+    term *= -x2 / n;
+    const delta = term / (2 * n + 1);
+    sum += delta;
+    if (Math.abs(delta) <= 1e-18 * Math.abs(sum)) break;
+  }
+  return TWO_OVER_SQRTPI * sum;
+}
+
+// Acklam's rational approximation for probit(p) = Phi^{-1}(p), ~1.15e-9 accuracy.
+function probitApprox(p: number): number {
+  const a = [-3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2,
+             1.383577518672690e2, -3.066479806614716e1, 2.506628277459239];
+  const b = [-5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2,
+             6.680131188771972e1, -1.328068155288572e1];
+  const c = [-7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838,
+             -2.549732539343734, 4.374664141464968, 2.938163982698783];
+  const d = [7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996, 3.754408661907416];
+
+  const pLow = 0.02425;
+  const pHigh = 1 - pLow;
+
+  if (p < pLow) {
+    const t = Math.sqrt(-2 * Math.log(p));
+    return (((((c[0]*t+c[1])*t+c[2])*t+c[3])*t+c[4])*t+c[5]) /
+           ((((d[0]*t+d[1])*t+d[2])*t+d[3])*t+1);
+  } else if (p <= pHigh) {
+    const u = p - 0.5;
+    const r = u * u;
+    return u * (((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r+a[5]) /
+               (((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r+1);
+  } else {
+    const t = Math.sqrt(-2 * Math.log(1 - p));
+    return -(((((c[0]*t+c[1])*t+c[2])*t+c[3])*t+c[4])*t+c[5]) /
+            ((((d[0]*t+d[1])*t+d[2])*t+d[3])*t+1);
+  }
+}
+
+export function erfinv(x: number): number {
+  if (x === 0) return 0;
+  if (x >= 1) return Infinity;
+  if (x <= -1) return -Infinity;
+
+  // Convert to probit: erfinv(x) = probit((x+1)/2) / sqrt(2)
+  let y = probitApprox((x + 1) / 2) / SQRT2;
+
+  // Newton-Raphson refinement: f(y) = erf(y) - x = 0, f'(y) = (2/sqrt(pi)) * exp(-y^2)
+  for (let i = 0; i < 4; i++) {
+    const ey = erfTaylor(y);
+    const dy = TWO_OVER_SQRTPI * Math.exp(-y * y);
+    if (dy === 0) break;
+    y -= (ey - x) / dy;
+  }
+
+  return y;
+}
+
+// Exported for testing — erf computed via the same Taylor series as the NR refinement uses.
+export function erfForTest(x: number): number {
+  return erfTaylor(x);
+}

--- a/src/scoring/scoreGame.ts
+++ b/src/scoring/scoreGame.ts
@@ -1,0 +1,128 @@
+import { Game } from '../game/Game';
+import { TbaCachedClient } from './tbaCachedClient';
+import { calculateDistrictPoints, DistrictPoints, parseTeamNames } from './districtPoints';
+import { reconstructPicks } from './draftHistory';
+
+export interface ScoringPickResult {
+  round: number;
+  pickIndex: number;
+  teamNumber: string;
+  teamName?: string;
+  pointsContributed: number;
+  rankAmongAvailable: number;  // 1 = best possible pick
+  poolSize: number;
+  percentile: number;          // (poolSize - rank + 1) / poolSize; 1.0 = best
+}
+
+export interface ScoringPlayer {
+  slackId: string;
+  name: string;
+  totalPoints: number;
+  picks: ScoringPickResult[];
+}
+
+export interface ScoringResponse {
+  game: {
+    uuid: string;
+    gameName: string;
+    eventCode: string;
+    allianceSize: number;
+    channelId: string;
+  };
+  event: {
+    code: string;
+    isFinal: boolean;
+  };
+  districtPoints: Record<string, DistrictPoints>;
+  players: ScoringPlayer[];
+}
+
+export interface ScoringUnavailableResponse {
+  scoringAvailable: false;
+  reason: string;
+}
+
+export async function scoreGame(
+  game: Game,
+  tbaClient: TbaCachedClient,
+): Promise<ScoringResponse | ScoringUnavailableResponse> {
+  const eventCode = game.eventCode;
+  if (!eventCode) {
+    return { scoringAvailable: false, reason: 'No event code attached to this game. Use /debug game <uuid> set event-code <code> to enable scoring.' };
+  }
+
+  const [tbaTeams, tbaRankings, tbaAlliances, tbaMatches, tbaAwards] = await Promise.all([
+    tbaClient.getTeams(eventCode),
+    tbaClient.getRankings(eventCode),
+    tbaClient.getAlliances(eventCode),
+    tbaClient.getMatches(eventCode),
+    tbaClient.getAwards(eventCode),
+  ]);
+
+  const districtPoints = calculateDistrictPoints({
+    rankings: tbaRankings ? tbaRankings.rankings.sort((a, b) => a.rank - b.rank).map(r => r.team_key.replace('frc', '')) : [],
+    alliances: tbaAlliances,
+    matches: tbaMatches,
+    awards: tbaAwards,
+    teams: tbaTeams,
+  });
+
+  const teamNames = parseTeamNames(tbaTeams);
+
+  const picks = reconstructPicks(game);
+  // Group picks by player
+  const picksByPlayer = new Map<string, typeof picks>();
+  for (const pick of picks) {
+    if (!picksByPlayer.has(pick.playerSlackId)) picksByPlayer.set(pick.playerSlackId, []);
+    picksByPlayer.get(pick.playerSlackId)!.push(pick);
+  }
+
+  const players: ScoringPlayer[] = game.players.map(player => {
+    const playerPicks = picksByPlayer.get(player.slackId) ?? [];
+    let totalPoints = 0;
+
+    const scoredPicks: ScoringPickResult[] = playerPicks.map(pick => {
+      const pts = districtPoints[pick.teamNumber];
+      const pointsContributed = pts?.total ?? 0;
+      totalPoints += pointsContributed;
+
+      // Rank among available: sort pool by total desc, ties broken by team number asc
+      const poolSorted = pick.poolBefore
+        .map(tn => ({ tn, total: districtPoints[tn]?.total ?? 0 }))
+        .sort((a, b) => b.total - a.total || parseInt(a.tn) - parseInt(b.tn));
+
+      const rankAmongAvailable = poolSorted.findIndex(p => p.tn === pick.teamNumber) + 1;
+      const poolSize = pick.poolBefore.length;
+      const percentile = poolSize > 0 ? (poolSize - rankAmongAvailable + 1) / poolSize : 1;
+
+      return {
+        round: pick.round,
+        pickIndex: pick.pickIndex,
+        teamNumber: pick.teamNumber,
+        teamName: teamNames.get(pick.teamNumber),
+        pointsContributed,
+        rankAmongAvailable: rankAmongAvailable || 1,
+        poolSize,
+        percentile,
+      };
+    });
+
+    return { slackId: player.slackId, name: player.name, totalPoints, picks: scoredPicks };
+  });
+
+  const isFinal = tbaAlliances.length > 0 &&
+    tbaAlliances.every(a => a.status?.status === 'won' || a.status?.status === 'eliminated');
+
+  return {
+    game: {
+      uuid: game.uuid,
+      gameName: game.gameName,
+      eventCode,
+      allianceSize: game.allianceSize,
+      channelId: game.channelId,
+    },
+    event: { code: eventCode, isFinal },
+    districtPoints,
+    players,
+  };
+}

--- a/src/scoring/tbaCachedClient.ts
+++ b/src/scoring/tbaCachedClient.ts
@@ -1,0 +1,88 @@
+import { TbaAward, TbaAlliance, TbaMatchSimple, TbaRankingsResponse, TbaTeamSimple } from './tbaTypes';
+
+interface CacheEntry {
+  body: unknown;
+  etag?: string;
+  lastModified?: string;
+  expiresAt: number;
+}
+
+export class TbaCachedClient {
+  private readonly apiKey: string;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async getTeams(eventCode: string): Promise<TbaTeamSimple[]> {
+    return (await this.fetch<TbaTeamSimple[]>(`event/${eventCode}/teams/simple`, 3600)) ?? [];
+  }
+
+  async getRankings(eventCode: string): Promise<TbaRankingsResponse | null> {
+    return this.fetch<TbaRankingsResponse>(`event/${eventCode}/rankings`, 30);
+  }
+
+  async getMatches(eventCode: string): Promise<TbaMatchSimple[]> {
+    return (await this.fetch<TbaMatchSimple[]>(`event/${eventCode}/matches/simple`, 30)) ?? [];
+  }
+
+  async getAlliances(eventCode: string): Promise<TbaAlliance[]> {
+    return (await this.fetch<TbaAlliance[]>(`event/${eventCode}/alliances`, 30)) ?? [];
+  }
+
+  async getAwards(eventCode: string): Promise<TbaAward[]> {
+    return (await this.fetch<TbaAward[]>(`event/${eventCode}/awards`, 300)) ?? [];
+  }
+
+  private async fetch<T>(endpoint: string, ttlSeconds: number): Promise<T | null> {
+    const key = endpoint;
+    const now = Date.now();
+    const entry = this.cache.get(key);
+
+    const headers: Record<string, string> = {
+      'X-TBA-Auth-Key': this.apiKey,
+      'User-Agent': 'FantasyFirstSlackBot/1.0',
+      'Accept': 'application/json',
+    };
+
+    if (entry) {
+      if (now < entry.expiresAt) return entry.body as T;
+      if (entry.etag) headers['If-None-Match'] = entry.etag;
+      if (entry.lastModified) headers['If-Modified-Since'] = entry.lastModified;
+    }
+
+    const url = `https://www.thebluealliance.com/api/v3/${endpoint}`;
+    let response: Response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (err) {
+      // Network error — return stale cache if available
+      if (entry) return entry.body as T;
+      throw err;
+    }
+
+    if (response.status === 304 && entry) {
+      entry.expiresAt = now + ttlSeconds * 1000;
+      return entry.body as T;
+    }
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      if (entry) return entry.body as T;
+      throw new Error(`TBA API error ${response.status} for ${endpoint}`);
+    }
+
+    const body = (await response.json()) as T;
+    this.cache.set(key, {
+      body,
+      etag: response.headers.get('ETag') ?? undefined,
+      lastModified: response.headers.get('Last-Modified') ?? undefined,
+      expiresAt: now + ttlSeconds * 1000,
+    });
+    return body;
+  }
+}

--- a/src/scoring/tbaTypes.ts
+++ b/src/scoring/tbaTypes.ts
@@ -1,0 +1,43 @@
+export interface TbaTeamSimple {
+  team_number: number;
+  nickname: string;
+  key: string;
+}
+
+export interface TbaRankingsResponse {
+  rankings: Array<{
+    team_key: string;
+    rank: number;
+  }>;
+}
+
+export interface TbaAllianceStatus {
+  record: { wins: number; losses: number; ties: number };
+  status: string;
+  double_elim_round?: string;
+}
+
+export interface TbaAlliance {
+  name?: string;
+  picks: string[];
+  status: TbaAllianceStatus;
+}
+
+export interface TbaMatchSimple {
+  alliances: {
+    red: { team_keys: string[]; score: number };
+    blue: { team_keys: string[]; score: number };
+  };
+  winning_alliance: 'red' | 'blue' | '';
+  comp_level: string;
+}
+
+export interface TbaAwardRecipient {
+  team_key: string | null;
+  awardee: string | null;
+}
+
+export interface TbaAward {
+  award_type: number;
+  recipient_list: TbaAwardRecipient[];
+}

--- a/src/slack/handlers/admin.ts
+++ b/src/slack/handlers/admin.ts
@@ -8,21 +8,22 @@ import { ADMIN_USER_ID } from '../../constants';
 
 const HELP = `
 *Fantasy First Admin Commands*
-\`/debug help\`                          — Show this message
-\`/debug games\`                         — List your games in this workspace
-\`/debug all\`                           — List ALL games in workspace (admin only)
-\`/debug game <uuid> info\`              — Show full game details
-\`/debug game <uuid> players\`           — List players
-\`/debug game <uuid> teams\`             — List available teams
-\`/debug game <uuid> add @user ...\`     — Add one or more players
-\`/debug game <uuid> kick @user\`        — Remove a player
-\`/debug game <uuid> unstart\`           — Reset draft to registration
-\`/debug game <uuid> reprint\`           — Post game message to channel again
-\`/debug game <uuid> set target <n>\`   — Set target players per draft
-\`/debug game <uuid> set alliance <n>\` — Set alliance (teams per player) size
-\`/debug game <uuid> rename <name>\`     — Rename the game
-\`/debug game <uuid> split-preview\`    — Preview how players would be split
-\`/debug game <uuid> delete\`            — Permanently delete the game
+\`/debug help\`                                  — Show this message
+\`/debug games\`                                 — List your games in this workspace
+\`/debug all\`                                   — List ALL games in workspace (admin only)
+\`/debug game <uuid> info\`                      — Show full game details
+\`/debug game <uuid> players\`                   — List players
+\`/debug game <uuid> teams\`                     — List available teams
+\`/debug game <uuid> add @user ...\`             — Add one or more players
+\`/debug game <uuid> kick @user\`                — Remove a player
+\`/debug game <uuid> unstart\`                   — Reset draft to registration
+\`/debug game <uuid> reprint\`                   — Post game message to channel again
+\`/debug game <uuid> set target <n>\`            — Set target players per draft
+\`/debug game <uuid> set alliance <n>\`          — Set alliance (teams per player) size
+\`/debug game <uuid> set event-code <code>\`     — Attach TBA event code for live scoring
+\`/debug game <uuid> rename <name>\`             — Rename the game
+\`/debug game <uuid> split-preview\`             — Preview how players would be split
+\`/debug game <uuid> delete\`                    — Permanently delete the game
 `.trim();
 
 export function registerAdminHandler(app: App): void {
@@ -152,6 +153,15 @@ export function registerAdminHandler(app: App): void {
 
         if (cmd === 'set' && args.length >= 5) {
           const field = args[3].toLowerCase();
+
+          if (field === 'event-code') {
+            const code = args[4].trim();
+            game.eventCode = code;
+            await saveGame(workspaceId, game.toData());
+            await respond({ text: `Event code set to \`${code}\`. Live scoring will be available once TBA data is available.`, response_type: 'ephemeral' });
+            return;
+          }
+
           const value = parseInt(args[4], 10);
           if (isNaN(value)) { await respond({ text: 'Value must be a number.', response_type: 'ephemeral' }); return; }
           if (field === 'target') {
@@ -159,7 +169,7 @@ export function registerAdminHandler(app: App): void {
           } else if (field === 'alliance') {
             game.allianceSize = value;
           } else {
-            await respond({ text: `Unknown field "${field}". Use "target" or "alliance".`, response_type: 'ephemeral' });
+            await respond({ text: `Unknown field "${field}". Use "target", "alliance", or "event-code".`, response_type: 'ephemeral' });
             return;
           }
           await saveGame(workspaceId, game.toData());

--- a/src/slack/handlers/createEvent.ts
+++ b/src/slack/handlers/createEvent.ts
@@ -43,9 +43,11 @@ export function registerCreateEventHandlers(app: App): void {
 
     try {
       const tbaApiKey = process.env.TBA_API_KEY ?? '';
-      const teams = teamListValue.includes(',')
-        ? parseTeamList(teamListValue)
-        : await getTeamsAtEvent(teamListValue.trim(), tbaApiKey);
+      const isTbaCode = !teamListValue.includes(',');
+      const eventCode = isTbaCode ? teamListValue.trim() : undefined;
+      const teams = isTbaCode
+        ? await getTeamsAtEvent(eventCode!, tbaApiKey)
+        : parseTeamList(teamListValue);
 
       if (teams.length === 0) {
         logger.warn('No teams found for input: %s', teamListValue);
@@ -59,6 +61,7 @@ export function registerCreateEventHandlers(app: App): void {
         gameOwnerSlackId: userId,
         gameName,
         targetPlayersPerGame: targetPlayerCount,
+        eventCode,
       });
 
       addGame(workspaceId, game);

--- a/src/slack/handlers/startGame.ts
+++ b/src/slack/handlers/startGame.ts
@@ -44,6 +44,7 @@ export function registerStartGameHandler(app: App): void {
           gameOwnerSlackId: game.gameOwnerSlackId,
           gameName: `${game.gameName} ${i + 1}`,
           targetPlayersPerGame: game.targetPlayersPerGame,
+          eventCode: game.eventCode,
         });
         sibling.players.push(...splitGroups[i]);
         addGame(workspaceId, sibling);

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,3 +35,11 @@ export function removeGame(workspaceId: string, gameId: string): void {
 export function getAllGamesMap(): Map<string, Map<string, Game>> {
   return games;
 }
+
+export function getGameByUuid(uuid: string): Game | undefined {
+  for (const wsMap of games.values()) {
+    const game = wsMap.get(uuid);
+    if (game) return game;
+  }
+  return undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,4 +32,5 @@ export interface GameData {
   turnCount: number;
   lastMessagesTsArray: string[];
   targetPlayersPerGame: number;
+  eventCode?: string;
 }

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -18,6 +18,7 @@ function toGameData(row: {
   turnCount: number;
   lastMessagesTsArray: unknown;
   targetPlayersPerGame: number;
+  eventCode: string | null;
 }): GameData {
   return {
     uuid: row.uuid,
@@ -31,6 +32,7 @@ function toGameData(row: {
     turnCount: row.turnCount,
     lastMessagesTsArray: row.lastMessagesTsArray as string[],
     targetPlayersPerGame: row.targetPlayersPerGame,
+    eventCode: row.eventCode ?? undefined,
   };
 }
 
@@ -60,6 +62,7 @@ export async function saveGame(workspaceId: string, game: GameData): Promise<voi
     turnCount: game.turnCount,
     lastMessagesTsArray: toJson(game.lastMessagesTsArray),
     targetPlayersPerGame: game.targetPlayersPerGame,
+    eventCode: game.eventCode ?? null,
   };
 
   await prisma.$transaction([
@@ -81,6 +84,7 @@ export async function saveGame(workspaceId: string, game: GameData): Promise<voi
         targetPlayersPerGame: game.targetPlayersPerGame,
         allianceSize: game.allianceSize,
         channelId: game.channelId,
+        eventCode: game.eventCode ?? null,
       },
     }),
   ]);

--- a/src/web/router.ts
+++ b/src/web/router.ts
@@ -1,0 +1,45 @@
+import { Router, Request, Response, static as serveStatic } from 'express';
+import path from 'path';
+import { getGameByUuid } from '../state';
+import { scoreGame } from '../scoring/scoreGame';
+import { TbaCachedClient } from '../scoring/tbaCachedClient';
+
+const tbaClient = new TbaCachedClient(process.env.TBA_API_KEY ?? '');
+
+const WEB_DIST = path.join(__dirname, '..', '..', 'web', 'dist');
+
+export function createWebRouter(): Router {
+  const router = Router();
+
+  // Static assets (immutable, long-lived)
+  router.use('/assets', serveStatic(path.join(WEB_DIST, 'assets'), {
+    maxAge: '1y',
+    immutable: true,
+  }));
+
+  // SPA shell for /game/:uuid
+  router.get('/game/:uuid', (_req: Request, res: Response) => {
+    res.sendFile(path.join(WEB_DIST, 'index.html'));
+  });
+
+  // Scoring API
+  router.get('/api/games/:uuid/scoring', async (req: Request, res: Response) => {
+    const { uuid } = req.params;
+    const game = getGameByUuid(uuid);
+    if (!game) {
+      res.status(404).json({ error: 'Game not found' });
+      return;
+    }
+
+    try {
+      const result = await scoreGame(game, tbaClient);
+      res.setHeader('Cache-Control', 'public, max-age=15');
+      res.json(result);
+    } catch (err) {
+      console.error('Error scoring game', err);
+      res.status(500).json({ error: 'Failed to compute scoring' });
+    }
+  });
+
+  return router;
+}

--- a/tests/scoring/districtPoints.test.ts
+++ b/tests/scoring/districtPoints.test.ts
@@ -1,0 +1,238 @@
+import {
+  parseRankings,
+  parseAlliances,
+  parseMatches,
+  parseAwards,
+  calculateDistrictPoints,
+  isSerpentine,
+} from '../../src/scoring/districtPoints';
+import type { TbaAlliance, TbaMatchSimple, TbaAward, TbaRankingsResponse, TbaTeamSimple } from '../../src/scoring/tbaTypes';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function mkRankings(teams: string[]): TbaRankingsResponse {
+  return { rankings: teams.map((t, i) => ({ team_key: `frc${t}`, rank: i + 1 })) };
+}
+
+function mkAlliance(num: number, picks: string[], wins: number, round: string, status = 'playing'): TbaAlliance {
+  return {
+    name: `Alliance ${num}`,
+    picks: picks.map(p => `frc${p}`),
+    status: {
+      record: { wins, losses: 0, ties: 0 },
+      status,
+      double_elim_round: round,
+    },
+  };
+}
+
+function mkMatch(red: string[], blue: string[], winner: 'red' | 'blue', level: string): TbaMatchSimple {
+  return {
+    alliances: {
+      red: { team_keys: red.map(t => `frc${t}`), score: 100 },
+      blue: { team_keys: blue.map(t => `frc${t}`), score: 50 },
+    },
+    winning_alliance: winner,
+    comp_level: level,
+  };
+}
+
+function mkTeams(nums: string[]): TbaTeamSimple[] {
+  return nums.map(n => ({ team_number: parseInt(n), nickname: `Team ${n}`, key: `frc${n}` }));
+}
+
+// ---------------------------------------------------------------------------
+// Parse helpers
+// ---------------------------------------------------------------------------
+
+describe('parseRankings', () => {
+  test('returns team numbers sorted by rank', () => {
+    const raw = mkRankings(['254', '1678', '4414']);
+    expect(parseRankings(raw)).toEqual(['254', '1678', '4414']);
+  });
+
+  test('handles null input', () => {
+    expect(parseRankings(null)).toEqual([]);
+  });
+});
+
+describe('parseAlliances', () => {
+  test('extracts alliance number, teams, wins, placement', () => {
+    const raw = [mkAlliance(1, ['1', '2', '3'], 5, 'Finals', 'won')];
+    const parsed = parseAlliances(raw);
+    expect(parsed[0].allianceNumber).toBe(1);
+    expect(parsed[0].teams).toEqual(['1', '2', '3']);
+    expect(parsed[0].wins).toBe(5);
+    expect(parsed[0].placement).toBe(1);
+  });
+
+  test('runner-up has placement 2', () => {
+    const raw = [mkAlliance(2, ['4', '5', '6'], 2, 'Finals', 'eliminated')];
+    expect(parseAlliances(raw)[0].placement).toBe(2);
+  });
+
+  test('Round 5 → placement 3', () => {
+    const raw = [mkAlliance(3, ['7', '8', '9'], 3, 'Round 5', 'eliminated')];
+    expect(parseAlliances(raw)[0].placement).toBe(3);
+  });
+});
+
+describe('parseMatches', () => {
+  test('detects quals and finals', () => {
+    const matches = parseMatches([
+      mkMatch(['1', '2', '3'], ['4', '5', '6'], 'red', 'qm'),
+      mkMatch(['1', '2', '3'], ['4', '5', '6'], 'blue', 'f'),
+    ]);
+    expect(matches[0].isQuals).toBe(true);
+    expect(matches[0].isFinals).toBe(false);
+    expect(matches[1].isQuals).toBe(false);
+    expect(matches[1].isFinals).toBe(true);
+    expect(matches[1].winner).toBe('blue');
+  });
+});
+
+describe('parseAwards', () => {
+  test('skips excluded award types 1, 2, 68', () => {
+    const raw: TbaAward[] = [
+      { award_type: 1, recipient_list: [{ team_key: 'frc1', awardee: null }] },
+      { award_type: 2, recipient_list: [{ team_key: 'frc2', awardee: null }] },
+      { award_type: 68, recipient_list: [{ team_key: 'frc3', awardee: null }] },
+    ];
+    expect(parseAwards(raw)).toHaveLength(0);
+  });
+
+  test('maps award types correctly', () => {
+    const raw: TbaAward[] = [
+      { award_type: 0, recipient_list: [{ team_key: 'frc1', awardee: null }] },
+      { award_type: 9, recipient_list: [{ team_key: 'frc2', awardee: null }] },
+      { award_type: 10, recipient_list: [{ team_key: 'frc3', awardee: null }] },
+      { award_type: 5, recipient_list: [{ team_key: 'frc4', awardee: null }] },
+    ];
+    const parsed = parseAwards(raw);
+    expect(parsed[0].awardType).toBe('impact');
+    expect(parsed[1].awardType).toBe('engineering_inspiration');
+    expect(parsed[2].awardType).toBe('rookie_all_star');
+    expect(parsed[3].awardType).toBe('other');
+  });
+
+  test('skips individual-person awardees', () => {
+    const raw: TbaAward[] = [
+      { award_type: 5, recipient_list: [{ team_key: 'frc1', awardee: 'John Doe' }] },
+    ];
+    expect(parseAwards(raw)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateDistrictPoints — golden output tests
+// ---------------------------------------------------------------------------
+
+describe('calculateDistrictPoints', () => {
+  // A minimal 4-team, 2-alliance event to keep fixtures manageable.
+  // Teams: '1' (rank 1), '2' (rank 2), '3' (rank 3), '4' (rank 4)
+  // Alliances: A1 = [1, 3], A2 = [2, 4]  (2-team alliances for simplicity)
+  // Playoffs: A1 wins 2 matches (Finals), A2 loses 1 final match
+  // A1 wins = 2, A2 wins = 1 (they won one match before losing)
+  // Awards: team '1' gets Impact Award (type 0)
+
+  const rawRankings = mkRankings(['1', '2', '3', '4']);
+  const rankings = parseRankings(rawRankings);
+  const alliances: TbaAlliance[] = [
+    mkAlliance(1, ['1', '3'], 2, 'Finals', 'won'),
+    mkAlliance(2, ['2', '4'], 1, 'Finals', 'eliminated'),
+  ];
+  const matches: TbaMatchSimple[] = [
+    // A2 won a semifinal (their 1 win in the tournament record)
+    mkMatch(['2', '4'], ['1', '3'], 'red', 'sf'),
+    // Finals: A1 wins both (A2 eliminated)
+    mkMatch(['1', '3'], ['2', '4'], 'red', 'f'),
+    mkMatch(['1', '3'], ['2', '4'], 'red', 'f'),
+  ];
+  const awards: TbaAward[] = [
+    { award_type: 0, recipient_list: [{ team_key: 'frc1', awardee: null }] },
+  ];
+  const teams = mkTeams(['1', '2', '3', '4']);
+
+  let pts: ReturnType<typeof calculateDistrictPoints>;
+
+  beforeAll(() => {
+    pts = calculateDistrictPoints({ rankings, alliances, matches, awards, teams });
+  });
+
+
+  test('all teams present in output', () => {
+    expect(Object.keys(pts)).toEqual(expect.arrayContaining(['1', '2', '3', '4']));
+  });
+
+  test('qual points decrease with rank', () => {
+    expect(pts['1'].qualPoints).toBeGreaterThan(pts['2'].qualPoints);
+    expect(pts['2'].qualPoints).toBeGreaterThan(pts['3'].qualPoints);
+    expect(pts['3'].qualPoints).toBeGreaterThan(pts['4'].qualPoints);
+  });
+
+  test('alliance captain points: A1 captain > A2 captain', () => {
+    // A1 captain is team '1', A2 captain is team '2'
+    // max_points = (alliance_size - 1) * num_alliances + 1 = (2-1)*2+1 = 3
+    // A1 captain: 3 - 1 = 2; A2 captain: 3 - 2 = 1
+    // '3' gets acceptance as first pick of A1: max_points - 1 = 2 (position 1 in serpentine)
+    // '4' gets acceptance as first pick of A2: max_points - 2 = 1 (position 2)
+    // Alliance points for '1' (captain only, no acceptance): 2
+    // Alliance points for '3' (acceptance pick 1): 2  (position 1 of 1 in first pick round)
+    expect(pts['1'].alliancePoints).toBeGreaterThan(pts['2'].alliancePoints);
+  });
+
+  test('impact award adds 10 points', () => {
+    expect(pts['1'].awardPoints).toBe(10);
+    expect(pts['2'].awardPoints).toBe(0);
+  });
+
+  test('winner gets elims points (placement=1, + finals bonus)', () => {
+    // A1 won 2 finals matches → elims: (2/2)*20 = 20, finals bonus: min(10, 2*5) = 10 → 30
+    expect(pts['1'].elimsPoints).toBeCloseTo(30, 1);
+    expect(pts['3'].elimsPoints).toBeCloseTo(30, 1);
+  });
+
+  test('runner-up gets elims points (placement=2, no finals bonus)', () => {
+    // A2 had 1 win, placement=2 → alliance_points=20
+    // team '2': (1/1)*20=20; no finals bonus (placement≠1)
+    expect(pts['2'].elimsPoints).toBeCloseTo(20, 1);
+    expect(pts['4'].elimsPoints).toBeCloseTo(20, 1);
+  });
+
+  test('total = qual + alliance + elims + award (no team_age)', () => {
+    for (const team of ['1', '2', '3', '4']) {
+      const p = pts[team];
+      expect(p.total).toBeCloseTo(p.qualPoints + p.alliancePoints + p.elimsPoints + p.awardPoints, 5);
+    }
+  });
+
+  test('partial event (rankings only, no alliances/matches/awards)', () => {
+    const partial = calculateDistrictPoints({
+      rankings: parseRankings(rawRankings),
+      alliances: [],
+      matches: [],
+      awards: [],
+      teams,
+    });
+    expect(partial['1'].alliancePoints).toBe(0);
+    expect(partial['1'].elimsPoints).toBe(0);
+    expect(partial['1'].awardPoints).toBe(0);
+    expect(partial['1'].qualPoints).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSerpentine
+// ---------------------------------------------------------------------------
+
+describe('isSerpentine', () => {
+  test('returns true for normal events', () => {
+    expect(isSerpentine('2024cala')).toBe(true);
+  });
+
+  test('returns false for IRI events', () => {
+    expect(isSerpentine('2024iri')).toBe(false);
+  });
+});

--- a/tests/scoring/draftHistory.test.ts
+++ b/tests/scoring/draftHistory.test.ts
@@ -1,0 +1,111 @@
+import { reconstructPicks } from '../../src/scoring/draftHistory';
+import { Game } from '../../src/game/Game';
+import { createTeam } from '../../src/types';
+
+function makeGame(allianceSize: number, playerNames: string[], picks: string[][]): Game {
+  const teams = Array.from({ length: allianceSize * playerNames.length }, (_, i) =>
+    createTeam(String(i + 1)),
+  );
+  const game = Game.create({
+    channelId: 'C123',
+    allianceSize,
+    teams,
+    gameOwnerSlackId: 'U0',
+    gameName: 'Test',
+  });
+
+  // Add players
+  for (let i = 0; i < playerNames.length; i++) {
+    game.players.push({ slackId: `U${i + 1}`, name: playerNames[i], selectedTeams: [] });
+  }
+
+  // Simulate picks: move teams from available to players
+  for (let round = 0; round < allianceSize; round++) {
+    const playerOrder = round % 2 === 0
+      ? [...game.players]
+      : [...game.players].reverse();
+
+    for (const player of playerOrder) {
+      const teamNum = picks[game.players.indexOf(player)]?.[round];
+      if (!teamNum) continue;
+      const idx = game.availableTeams.findIndex(t => t.number === teamNum);
+      if (idx >= 0) {
+        const [team] = game.availableTeams.splice(idx, 1);
+        player.selectedTeams.push(team);
+      }
+    }
+  }
+
+  // Mark as started
+  (game as unknown as { data: { hasStarted: boolean } }).data.hasStarted = true;
+
+  return game;
+}
+
+describe('reconstructPicks', () => {
+  test('returns empty array for unstarted game', () => {
+    const game = Game.create({
+      channelId: 'C1',
+      allianceSize: 2,
+      teams: [createTeam('1'), createTeam('2'), createTeam('3'), createTeam('4')],
+      gameOwnerSlackId: 'U0',
+      gameName: 'Test',
+    });
+    expect(reconstructPicks(game)).toHaveLength(0);
+  });
+
+  test('2 players, 2 rounds — snake order', () => {
+    // Player A picks first in round 1 (odd), Player B picks first in round 2 (even reversed)
+    // Round 1: A picks '1', B picks '2'
+    // Round 2 (reversed): B picks '3', A picks '4'
+    const game = makeGame(2, ['Alice', 'Bob'], [['1', '4'], ['2', '3']]);
+    const picks = reconstructPicks(game);
+    expect(picks).toHaveLength(4);
+
+    // Round 1: Alice first
+    expect(picks[0].playerName).toBe('Alice');
+    expect(picks[0].round).toBe(1);
+    expect(picks[0].teamNumber).toBe('1');
+    expect(picks[0].poolBefore).toHaveLength(4);  // all 4 teams available
+
+    // Round 1: Bob second
+    expect(picks[1].playerName).toBe('Bob');
+    expect(picks[1].round).toBe(1);
+    expect(picks[1].teamNumber).toBe('2');
+    expect(picks[1].poolBefore).toHaveLength(3);  // team '1' already picked
+
+    // Round 2 (reversed): Bob first
+    expect(picks[2].playerName).toBe('Bob');
+    expect(picks[2].round).toBe(2);
+    expect(picks[2].teamNumber).toBe('3');
+    expect(picks[2].poolBefore).toHaveLength(2);
+
+    // Round 2: Alice last
+    expect(picks[3].playerName).toBe('Alice');
+    expect(picks[3].round).toBe(2);
+    expect(picks[3].teamNumber).toBe('4');
+    expect(picks[3].poolBefore).toHaveLength(1);
+  });
+
+  test('pool shrinks correctly after each pick', () => {
+    const game = makeGame(2, ['Alice', 'Bob'], [['1', '4'], ['2', '3']]);
+    const picks = reconstructPicks(game);
+
+    for (let i = 1; i < picks.length; i++) {
+      expect(picks[i].poolBefore).toHaveLength(picks[i - 1].poolBefore.length - 1);
+    }
+  });
+
+  test('3 players, 3 rounds — pool size decreases by 1 each pick', () => {
+    // 9 teams total, 3 players, 3 rounds
+    const game = makeGame(3, ['A', 'B', 'C'], [
+      ['1', '6', '7'],  // A: round1, round2(last in reversed order), round3
+      ['2', '5', '8'],
+      ['3', '4', '9'],
+    ]);
+    const picks = reconstructPicks(game);
+    expect(picks).toHaveLength(9);
+    expect(picks[0].poolBefore).toHaveLength(9);
+    expect(picks[8].poolBefore).toHaveLength(1);
+  });
+});

--- a/tests/scoring/erfinv.test.ts
+++ b/tests/scoring/erfinv.test.ts
@@ -1,0 +1,60 @@
+import { erfinv, erfForTest } from '../../src/scoring/erfinv';
+
+const tol = 1e-9;
+
+function expectClose(a: number, b: number, tolerance = tol): void {
+  expect(Math.abs(a - b)).toBeLessThan(tolerance);
+}
+
+describe('erfinv', () => {
+  test('boundary values', () => {
+    expect(erfinv(0)).toBe(0);
+    expect(erfinv(1)).toBe(Infinity);
+    expect(erfinv(-1)).toBe(-Infinity);
+  });
+
+  test('odd function symmetry', () => {
+    const vals = [0.1, 0.3, 0.5, 0.7, 0.9, 0.93, 1 / 1.07];
+    for (const x of vals) {
+      expectClose(erfinv(-x), -erfinv(x));
+    }
+  });
+
+  test('round-trip: erfinv(erf(y)) ≈ y', () => {
+    const ys = [0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, -1.2, -0.7];
+    for (const y of ys) {
+      const x = erfForTest(y);
+      if (Math.abs(x) >= 1) continue;  // clipped domain
+      expectClose(erfinv(x), y);
+    }
+  });
+
+  test('erfinv(1/1.07) used in qual-point normalisation', () => {
+    // This value appears in the Python as erfinv(1/a) where a=1.07.
+    // For first-place (rank=1, n teams): x = n/(1.07*n) = 1/1.07 exactly.
+    // Verify round-trip: erf(erfinv(1/1.07)) ≈ 1/1.07
+    const x = 1 / 1.07;
+    const y = erfinv(x);
+    expectClose(erfForTest(y), x);
+    // Value should be positive (first place → positive score boost)
+    expect(y).toBeGreaterThan(1.2);
+    expect(y).toBeLessThan(1.5);
+  });
+
+  test('known approximate values', () => {
+    // erf(0.5) ≈ 0.5205 → erfinv(0.5205) ≈ 0.5
+    expectClose(erfinv(erfForTest(0.5)), 0.5);
+    // erf(1) ≈ 0.8427
+    expectClose(erfinv(erfForTest(1.0)), 1.0);
+    // erf(2) ≈ 0.9953
+    expectClose(erfinv(erfForTest(2.0)), 2.0);
+  });
+
+  test('sampled points across (-1, 1)', () => {
+    const points = [-0.99, -0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99];
+    for (const x of points) {
+      const y = erfinv(x);
+      expectClose(erfForTest(y), x, 1e-8);  // round-trip to 1e-8
+    }
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fantasy First — Live Scoring</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,2712 @@
+{
+  "name": "fantasy-first-web",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fantasy-first-web",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "swr": "^2.2.5"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.5",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.47",
+        "tailwindcss": "^3.4.14",
+        "typescript": "^5.5.3",
+        "vite": "^5.4.8"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.45.tgz",
+      "integrity": "sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "fantasy-first-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "swr": "^2.2.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.5.3",
+    "vite": "^5.4.8"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { GameScoringPage } from './pages/GameScoringPage';
+
+export function App(): JSX.Element {
+  return <GameScoringPage />;
+}

--- a/web/src/components/DraftTable.tsx
+++ b/web/src/components/DraftTable.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ScoringPlayer, DistrictPoints } from '../types';
+import { TeamChip } from './TeamChip';
+
+interface DraftTableProps {
+  players: ScoringPlayer[];
+  districtPoints: Record<string, DistrictPoints>;
+}
+
+export function DraftTable({ players, districtPoints }: DraftTableProps): JSX.Element {
+  return (
+    <div className="space-y-4">
+      {players.map(player => (
+        <div key={player.slackId} className="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+          <div className="font-semibold text-gray-800 mb-2">
+            {player.name}
+            <span className="ml-2 text-sm text-gray-400 font-normal font-mono">
+              {player.totalPoints.toFixed(1)} pts
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {player.picks.length === 0 ? (
+              <span className="text-gray-400 text-sm italic">No picks yet</span>
+            ) : (
+              player.picks.map((pick, i) => (
+                <TeamChip
+                  key={i}
+                  pick={pick}
+                  points={districtPoints[pick.teamNumber]}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/PlayerScoreboard.tsx
+++ b/web/src/components/PlayerScoreboard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { ScoringPlayer } from '../types';
+
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+interface PlayerScoreboardProps {
+  players: ScoringPlayer[];
+}
+
+export function PlayerScoreboard({ players }: PlayerScoreboardProps): JSX.Element {
+  const sorted = [...players].sort((a, b) => b.totalPoints - a.totalPoints);
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="px-4 py-3 border-b border-gray-100">
+        <h2 className="font-semibold text-gray-700 text-sm uppercase tracking-wide">Standings</h2>
+      </div>
+      <ul className="divide-y divide-gray-50">
+        {sorted.map((player, idx) => (
+          <li key={player.slackId} className="flex items-center justify-between px-4 py-3">
+            <span className="flex items-center gap-2">
+              <span className="text-lg w-7 text-center">{MEDALS[idx] ?? `${idx + 1}.`}</span>
+              <span className="font-medium text-gray-800">{player.name}</span>
+            </span>
+            <span className="font-mono font-semibold text-gray-700">{player.totalPoints.toFixed(1)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/TeamChip.tsx
+++ b/web/src/components/TeamChip.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { ScoringPickResult, DistrictPoints } from '../types';
+import { pickColor } from '../lib/colors';
+import { Tooltip } from './Tooltip';
+
+interface TeamChipProps {
+  pick: ScoringPickResult;
+  points: DistrictPoints | undefined;
+}
+
+export function TeamChip({ pick, points }: TeamChipProps): JSX.Element {
+  const colors = pickColor(pick.percentile);
+  const label = pick.teamName ? `${pick.teamNumber}` : pick.teamNumber;
+
+  const tooltipContent = (
+    <div className="space-y-1">
+      <div className="font-semibold">
+        Team {pick.teamNumber}{pick.teamName ? ` — ${pick.teamName}` : ''}
+      </div>
+      <div className="text-gray-500 text-xs">
+        +{pick.pointsContributed.toFixed(1)} pts contributed
+      </div>
+      <div className="text-gray-500 text-xs">
+        Pick quality: #{pick.rankAmongAvailable} of {pick.poolSize} available
+      </div>
+      {points && (
+        <table className="mt-2 w-full text-xs border-t border-gray-100 pt-1">
+          <tbody>
+            <tr><td className="py-0.5 text-gray-500">Qual</td><td className="text-right font-mono">{points.qualPoints}</td></tr>
+            <tr><td className="py-0.5 text-gray-500">Alliance</td><td className="text-right font-mono">{points.alliancePoints}</td></tr>
+            <tr><td className="py-0.5 text-gray-500">Elims</td><td className="text-right font-mono">{points.elimsPoints.toFixed(1)}</td></tr>
+            <tr><td className="py-0.5 text-gray-500">Awards</td><td className="text-right font-mono">{points.awardPoints}</td></tr>
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <span
+        className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold ring-1 ring-inset select-none ${colors.bg} ${colors.text} ${colors.ring}`}
+        title={pick.teamName}
+      >
+        {label}
+      </span>
+    </Tooltip>
+  );
+}

--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef, useEffect, ReactNode } from 'react';
+
+interface TooltipProps {
+  content: ReactNode;
+  children: ReactNode;
+}
+
+export function Tooltip({ content, children }: TooltipProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Dismiss on outside click / tap
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent | TouchEvent): void {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handler);
+    document.addEventListener('touchstart', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('touchstart', handler);
+    };
+  }, [open]);
+
+  // Dismiss on Esc
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: KeyboardEvent): void {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <div
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onClick={() => setOpen(v => !v)}
+        className="cursor-pointer"
+      >
+        {children}
+      </div>
+      {open && (
+        <div
+          className="absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 rounded-lg shadow-xl border border-gray-200 bg-white text-gray-800 text-sm p-3"
+          role="tooltip"
+        >
+          {content}
+          <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-px border-4 border-transparent border-t-white" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse {
+    animation: none;
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,16 @@
+import type { ApiResponse } from '../types';
+
+export function getGameUuid(): string {
+  // Extract UUID from /game/<uuid>
+  const parts = window.location.pathname.split('/');
+  return parts[parts.length - 1] ?? '';
+}
+
+export async function fetchScoring(uuid: string): Promise<ApiResponse> {
+  const res = await fetch(`/api/games/${uuid}/scoring`);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error((err as { error?: string }).error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<ApiResponse>;
+}

--- a/web/src/lib/colors.ts
+++ b/web/src/lib/colors.ts
@@ -1,0 +1,13 @@
+export interface PickColors {
+  bg: string;
+  text: string;
+  ring: string;
+}
+
+export function pickColor(percentile: number): PickColors {
+  if (percentile >= 0.90) return { bg: 'bg-emerald-500', text: 'text-white',    ring: 'ring-emerald-600' };
+  if (percentile >= 0.75) return { bg: 'bg-green-400',   text: 'text-gray-900', ring: 'ring-green-500'   };
+  if (percentile >= 0.50) return { bg: 'bg-yellow-300',  text: 'text-gray-900', ring: 'ring-yellow-500'  };
+  if (percentile >= 0.25) return { bg: 'bg-orange-400',  text: 'text-white',    ring: 'ring-orange-500'  };
+  return                          { bg: 'bg-red-500',     text: 'text-white',    ring: 'ring-red-600'     };
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/web/src/pages/GameScoringPage.tsx
+++ b/web/src/pages/GameScoringPage.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import useSWR from 'swr';
+import { fetchScoring, getGameUuid } from '../lib/api';
+import { isScoringAvailable, ApiResponse } from '../types';
+import { PlayerScoreboard } from '../components/PlayerScoreboard';
+import { DraftTable } from '../components/DraftTable';
+
+const POLL_INTERVAL = 15_000;
+
+function formatAge(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  return `${Math.floor(s / 60)}m ago`;
+}
+
+export function GameScoringPage(): JSX.Element {
+  const uuid = getGameUuid();
+  const [lastUpdated, setLastUpdated] = React.useState<number | null>(null);
+  const { data, error, isLoading } = useSWR<ApiResponse, Error>(
+    uuid ? uuid : null,
+    fetchScoring,
+    {
+      refreshInterval: POLL_INTERVAL,
+      revalidateOnFocus: true,
+      onSuccess: () => setLastUpdated(Date.now()),
+    },
+  );
+
+  const now = Date.now();
+  const age = lastUpdated ? now - lastUpdated : null;
+
+  if (!uuid) {
+    return <ErrorState message="No game UUID in URL." />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-gray-400 animate-pulse">Loading scoring data…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <ErrorState message={`Failed to load: ${error.message}`} />;
+  }
+
+  if (!data) return <></>;
+
+  if (!isScoringAvailable(data)) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+        <div className="max-w-md text-center space-y-3">
+          <div className="text-4xl">📊</div>
+          <h1 className="text-xl font-semibold text-gray-800">Scoring not yet available</h1>
+          <p className="text-gray-500">{data.reason}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { game, event, players, districtPoints } = data;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Sticky header */}
+      <header className="sticky top-0 z-10 bg-white border-b border-gray-200 shadow-sm">
+        <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+          <div>
+            <h1 className="font-bold text-gray-800 text-base leading-tight">{game.gameName}</h1>
+            <div className="text-xs text-gray-400">
+              Event {event.code.toUpperCase()}
+              {event.isFinal && <span className="ml-2 text-emerald-600 font-medium">· Final</span>}
+            </div>
+          </div>
+          {age !== null && (
+            <div className="text-xs text-gray-400 tabular-nums">
+              Updated {formatAge(age)}
+            </div>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-4 py-6">
+        {/* Color legend */}
+        <div className="mb-4 flex flex-wrap gap-2 text-xs">
+          {[
+            { label: 'Top 10%', cls: 'bg-emerald-500 text-white' },
+            { label: 'Top 25%', cls: 'bg-green-400 text-gray-900' },
+            { label: 'Top 50%', cls: 'bg-yellow-300 text-gray-900' },
+            { label: 'Top 75%', cls: 'bg-orange-400 text-white' },
+            { label: 'Bottom 25%', cls: 'bg-red-500 text-white' },
+          ].map(({ label, cls }) => (
+            <span key={label} className={`px-2 py-0.5 rounded-full font-medium ${cls}`}>{label}</span>
+          ))}
+        </div>
+
+        {/* Responsive layout: scoreboard left + draft grid right on md+ */}
+        <div className="md:grid md:grid-cols-[280px_1fr] md:gap-6 space-y-6 md:space-y-0">
+          <PlayerScoreboard players={players} />
+          <DraftTable players={players} districtPoints={districtPoints} />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }): JSX.Element {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="max-w-md text-center space-y-3">
+        <div className="text-4xl">⚠️</div>
+        <h1 className="text-xl font-semibold text-gray-800">Something went wrong</h1>
+        <p className="text-gray-500 text-sm">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,53 @@
+export interface DistrictPoints {
+  teamNumber: string;
+  qualPoints: number;
+  alliancePoints: number;
+  elimsPoints: number;
+  awardPoints: number;
+  total: number;
+}
+
+export interface ScoringPickResult {
+  round: number;
+  pickIndex: number;
+  teamNumber: string;
+  teamName?: string;
+  pointsContributed: number;
+  rankAmongAvailable: number;
+  poolSize: number;
+  percentile: number;
+}
+
+export interface ScoringPlayer {
+  slackId: string;
+  name: string;
+  totalPoints: number;
+  picks: ScoringPickResult[];
+}
+
+export interface ScoringResponse {
+  game: {
+    uuid: string;
+    gameName: string;
+    eventCode: string;
+    allianceSize: number;
+    channelId: string;
+  };
+  event: {
+    code: string;
+    isFinal: boolean;
+  };
+  districtPoints: Record<string, DistrictPoints>;
+  players: ScoringPlayer[];
+}
+
+export interface ScoringUnavailableResponse {
+  scoringAvailable: false;
+  reason: string;
+}
+
+export type ApiResponse = ScoringResponse | ScoringUnavailableResponse;
+
+export function isScoringAvailable(r: ApiResponse): r is ScoringResponse {
+  return (r as ScoringUnavailableResponse).scoringAvailable !== false;
+}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
+});


### PR DESCRIPTION
### TL;DR

Adds a live scoring web UI that fetches FRC district points from The Blue Alliance and displays per-player draft results in a React SPA served directly by the bot.

### What changed?

**Scoring engine (`src/scoring/`)**
- `districtPoints.ts` — Ports the FRC district points calculation (qual points via inverse error function, alliance selection points, elims points, award points) from a Python reference implementation. Includes TBA response parsers for rankings, alliances, matches, and awards.
- `erfinv.ts` — Implements the inverse error function using Acklam's rational approximation followed by Newton-Raphson refinement, matching `scipy.special.erfinv` to within ~1e-12.
- `tbaCachedClient.ts` — HTTP client for The Blue Alliance API v3 with in-memory ETag/Last-Modified caching and configurable TTLs per endpoint.
- `draftHistory.ts` — Reconstructs the snake-draft pick order from a completed `Game`, recording the available team pool at each pick moment.
- `scoreGame.ts` — Orchestrates the above: fetches TBA data, computes district points, scores each player's picks, and annotates each pick with its rank among available teams and a percentile quality score.

**Game model**
- Added an optional `eventCode` field to `Game`, `GameData`, the Prisma schema, and persistence layer. When a game is created from a TBA event code (rather than a comma-separated team list), the event code is automatically stored. It propagates to sibling games created during a split.
- Added a `getScoringUrl(publicUrl)` helper that returns a `/game/<uuid>` link when `PUBLIC_URL` is set.
- Slack messages (lobby, draft complete, and mid-draft views) now include a `📊 Live Scoring` context block when `PUBLIC_URL` is configured.

**Admin command**
- `/debug game <uuid> set event-code <code>` attaches a TBA event code to an existing game, enabling scoring retroactively.

**Web frontend (`web/`)**
- React 18 + Vite + Tailwind SPA with a single `GameScoringPage` that polls `/api/games/:uuid/scoring` every 15 seconds via SWR.
- `PlayerScoreboard` shows ranked standings with medal emojis.
- `DraftTable` shows each player's picks as color-coded chips (green → red by pick percentile) with a tooltip breaking down qual/alliance/elims/award points and pick quality rank.
- Built into `web/dist/` and served as static assets by the Express router.

**Server**
- Switched from the default Slack Bolt HTTP adapter to `ExpressReceiver`, mounting a custom Express router before Slack's middleware.
- The router serves the Vite-built SPA at `/game/:uuid`, static assets at `/assets/`, and the scoring JSON API at `/api/games/:uuid/scoring` (15-second `Cache-Control`).
- `PUBLIC_URL` env var (no trailing slash) controls whether scoring links appear in Slack messages. Omitting it disables links for local dev.

**Docker**
- Added a `web-builder` stage that runs `npm ci && npm run build` in the `web/` directory. The compiled `web/dist/` is copied into the production image alongside `dist/`.

**Tests**
- `erfinv.test.ts` — boundary values, odd-function symmetry, round-trip accuracy, and sampled points across (−1, 1).
- `districtPoints.test.ts` — parse helpers and a golden-output integration test covering a 4-team, 2-alliance event with qual points, alliance points, elims points (including finals bonus), and award points.
- `draftHistory.test.ts` — snake-draft reconstruction for 2-player/2-round and 3-player/3-round scenarios, verifying pick order and pool shrinkage.

### How to test?

1. Set `TBA_API_KEY` to a valid key and `PUBLIC_URL=http://localhost:3000` in `.env`.
2. Create a game using a TBA event code (e.g. `2025cala`) — the event code will be stored automatically.
3. Start the bot (`npm run dev`) and open `http://localhost:3000/game/<uuid>` in a browser. The scoring page should load and poll for updates.
4. For an existing game without an event code, run `/debug game <uuid> set event-code <code>` and reload the page.
5. Run `npm test` to verify the scoring unit tests pass.

### Why make this change?

Draft participants currently have no way to track how their picked teams are performing at the event in real time. This adds a self-hosted live scoring page that computes FRC district points from TBA data and shows each player's standing, pick quality, and team breakdowns — all without requiring any external service beyond TBA's public API.